### PR TITLE
Make only keepers and very_old_twelves active

### DIFF
--- a/recordvalidator.go
+++ b/recordvalidator.go
@@ -310,6 +310,8 @@ func (s *Server) load(ctx context.Context) (*pb.Schemes, error) {
 			scheme.Order = pb.Scheme_GIVEN_ORDER
 		}
 
+		// Ensure only keepers and very_old_twelves are active
+		scheme.Active = (scheme.GetName() == "keepers" || scheme.GetName() == "very_old_twelves")
 	}
 
 	return schemes, nil


### PR DESCRIPTION
Updates recordvalidator.go to only activate the two requested schemes.